### PR TITLE
Fix three bugs: duplicate signal, broken stdout restore, replace-all undo

### DIFF
--- a/nuke_code_bridge.py
+++ b/nuke_code_bridge.py
@@ -1220,14 +1220,20 @@ class NukeCodeBridge(QtWidgets.QWidget):
         search_text = self.editor_search_edit.text()
         if not search_text:
             self._append_console("Please enter text to find.", "error"); return
-        content = editor.toPlainText()
-        count = content.count(search_text)
+        replace_text = self.editor_replace_edit.text()
+        count = editor.toPlainText().count(search_text)
         if count == 0:
             self._append_console(f"No occurrences of '{search_text}' found.", "info"); return
-        cursor = editor.textCursor()
-        cursor.beginEditBlock()
-        editor.setPlainText(content.replace(search_text, self.editor_replace_edit.text()))
-        cursor.endEditBlock()
+        doc = editor.document()
+        block_cursor = QtGui.QTextCursor(doc)
+        block_cursor.beginEditBlock()
+        find_cursor = QtGui.QTextCursor(doc)
+        while True:
+            find_cursor = doc.find(search_text, find_cursor)
+            if find_cursor.isNull():
+                break
+            find_cursor.insertText(replace_text)
+        block_cursor.endEditBlock()
         self._append_console(f"Replaced {count} occurrence(s).", "info")
 
     # ------------------------------------------------------------------
@@ -1458,7 +1464,6 @@ class NukeCodeBridge(QtWidgets.QWidget):
             editor.zoomOut(-self.global_zoom)
         editor.textChanged.connect(self._on_editor_modified)
         editor.zoomChanged.connect(self._on_editor_zoom_changed)
-        editor.textChanged.connect(self._save_session_state)
         return editor
 
     # ------------------------------------------------------------------
@@ -2499,9 +2504,6 @@ class NukeCodeBridge(QtWidgets.QWidget):
             self._append_console("PYTHON ERROR:", "error")
             self._append_console("".join(traceback.format_exception(etype, value, tb)), "error")
             self._append_console("-" * 50, "error")
-        finally:
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
 
         self.status_light.setStyleSheet(
             "color:#6A9955; font-size:18px;" if success else "color:#F44747; font-size:18px;"


### PR DESCRIPTION
## Summary

- **Duplicate `textChanged` signal** — `_create_editor` was connecting `textChanged → _save_session_state` twice, causing the session recovery file to be written twice on every single keystroke.
- **Broken stdout/stderr restore** — `_run_code_block` had a `finally` block that restored `sys.stdout`/`sys.stderr` to `sys.__stdout__`/`sys.__stderr__` (the original system streams), silently discarding any outer redirections already in place inside Nuke. The `StreamRedirector` context manager already correctly restores them via `__exit__`, so the `finally` block was redundant and harmful.
- **`_replace_all` destroyed undo history** — the implementation called `editor.setPlainText(...)` which replaces the entire document, wiping the undo stack and resetting cursor position. Replaced with an iterative `QTextCursor`-based find-and-replace inside a `beginEditBlock`/`endEditBlock` pair so replace-all appears as a single undoable operation.

## Test plan

- [ ] Open a script tab and type several characters — confirm `_save_session_state` is called once per change (add a `print` temporarily, or check that the `.session_recovery.json` write count halves)
- [ ] Run a script that prints output; verify output appears in the console and that Nuke's own Script Editor output is unaffected after the run
- [ ] Use Find & Replace → Replace All on a file with multiple matches; confirm all occurrences are replaced, cursor position is preserved, and Ctrl+Z undoes the entire replacement in one step

https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8)_