### PR TITLE
Call processEvents() during write_meta lock wait to prevent UI freeze

### DIFF
--- a/nuke_code_bridge.py
+++ b/nuke_code_bridge.py
@@ -116,6 +116,7 @@ def write_meta(scripts_folder, script_name, data):
             if time.time() - os.path.getmtime(lock) > 10:
                 os.remove(lock); break
         except Exception: pass
+        QtWidgets.QApplication.processEvents()
         time.sleep(0.5)
     try:
         with open(lock, "w") as f: f.write(str(os.getpid()))


### PR DESCRIPTION
## Summary

`write_meta` retries up to 3 times (× 0.5 s sleep) when a lock file is held by another process. Because this runs on the main Qt thread, the entire UI would freeze for up to ~1.5 s on a slow network share — no repaints, no input handling.

Adding `QApplication.processEvents()` before each sleep lets Qt flush pending repaints and input events during the wait, keeping the interface visibly responsive.

## Test plan

- [ ] On a machine with access to the configured network share, open two Nuke instances and trigger simultaneous metadata writes (e.g. save a description in both at the same moment)
- [ ] Confirm the UI remains responsive (cursor still moves, window repaints) during the brief lock-wait period rather than appearing frozen

https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8)_