### PR TITLE
Replace os.system() folder-open calls with subprocess.run()

### DIFF
--- a/nuke_code_bridge.py
+++ b/nuke_code_bridge.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import re
 import os
 import sys
+import subprocess
 import traceback
 import datetime
 import __main__
@@ -911,9 +912,9 @@ class SnippetManagerDialog(QtWidgets.QDialog):
             if sys.platform.startswith("win"):
                 os.startfile(folder)
             elif sys.platform == "darwin":
-                os.system(f'open "{folder}"')
+                subprocess.run(["open", folder])
             else:
-                os.system(f'xdg-open "{folder}"')
+                subprocess.run(["xdg-open", folder])
         except Exception as e:
             QtWidgets.QMessageBox.warning(self, "Error", str(e))
 
@@ -2722,8 +2723,8 @@ class NukeCodeBridge(QtWidgets.QWidget):
         folder = os.path.dirname(path)
         try:
             if sys.platform.startswith("win"): os.startfile(folder)
-            elif sys.platform == "darwin": os.system(f'open "{folder}"')
-            else: os.system(f'xdg-open "{folder}"')
+            elif sys.platform == "darwin": subprocess.run(["open", folder])
+            else: subprocess.run(["xdg-open", folder])
         except Exception as e:
             self._append_console(f"Failed to open folder: {e}")
 


### PR DESCRIPTION
## Summary

Two places in the code use `os.system(f'open "{folder}"')` / `os.system(f'xdg-open "{folder}"')` to open a folder in the OS file manager. This passes a shell-interpolated string to a subshell, which Bandit flags as B605/B607. Replaced with `subprocess.run(["open", folder])` / `subprocess.run(["xdg-open", folder])`, which passes the argument directly to the process with no shell involved, eliminating any injection risk from unexpected characters in the path.

Also adds the missing `import subprocess` to the standard-library imports block.

## Test plan

- [ ] Right-click a script in the sidebar and choose "Open Folder" — confirm the folder opens in Finder (macOS) or file manager (Linux)
- [ ] Open a snippet file location from the Snippet Manager dialog — confirm same behaviour
- [ ] Run Bandit; B605/B607 warnings on these lines should be gone

https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1PonJPKzEiMpnTMbpqDz8)_